### PR TITLE
Add adjustable feedback parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and [`src/ui.cpp`](src/ui.cpp).
 ## Features
 The firmware exposes several parameters, as defined in `controls.cpp`:
 - **Delay time** &ndash; sets the delay length in milliseconds.
-- **Feedback** &ndash; adjusts how much of the delayed signal is fed back.
+- **Feedback** (`feedbackAmount`) &ndash; sets how much of the delayed signal is routed back to the delay input.
 - **Noise amount** &ndash; controls bit‑crushing/noise applied to the feedback path.
 - **Density** &ndash; governs how often noisy glitches are added.
 - **Mix** &ndash; blends between the clean and dirty signals.

--- a/include/audio_pipeline.h
+++ b/include/audio_pipeline.h
@@ -12,8 +12,10 @@ extern AudioPlayQueue queueL, queueR;
 extern AudioPlayQueue cleanQueueL, cleanQueueR;
 extern AudioEffectEnvelope limiter1;
 extern AudioOutputI2S i2sOut;
+extern AudioMixer4 feedbackMixer;
 
 extern float mixAmount;
+extern float feedbackAmount;
 
 void setupAudioPipeline();
 void processAudioQueues();

--- a/src/audio_pipeline.cpp
+++ b/src/audio_pipeline.cpp
@@ -15,16 +15,21 @@ AudioPlayQueue         queueL, queueR;
 AudioPlayQueue         cleanQueueL, cleanQueueR;
 AudioEffectEnvelope    limiter1;
 AudioOutputI2S         i2sOut;
+AudioMixer4           feedbackMixer;
+
+float feedbackAmount = 0.0f;
 
 // === Audio Connections ===
 AudioConnection patchCord1(i2sIn, 0, filter1, 0);
-AudioConnection patchCord2(filter1, 0, delay1, 0);
-AudioConnection patchCord3(filter1, 0, cleanQueueL, 0);
-AudioConnection patchCord4(filter1, 0, cleanQueueR, 0);
-AudioConnection patchCord5(delay1, 0, queueL, 0);
-AudioConnection patchCord6(delay1, 1, queueR, 0);
-AudioConnection patchCord7(limiter1, 0, i2sOut, 0);
-AudioConnection patchCord8(limiter1, 1, i2sOut, 1);
+AudioConnection patchCord2(filter1, 0, feedbackMixer, 0);
+AudioConnection patchCord3(delay1, 0, feedbackMixer, 1);
+AudioConnection patchCord4(feedbackMixer, 0, delay1, 0);
+AudioConnection patchCord5(filter1, 0, cleanQueueL, 0);
+AudioConnection patchCord6(filter1, 0, cleanQueueR, 0);
+AudioConnection patchCord7(delay1, 0, queueL, 0);
+AudioConnection patchCord8(delay1, 1, queueR, 0);
+AudioConnection patchCord9(limiter1, 0, i2sOut, 0);
+AudioConnection patchCord10(limiter1, 1, i2sOut, 1);
 
 float processDirt(float sample) {
   // Bit-crush the incoming sample to introduce dirt/noise
@@ -80,6 +85,9 @@ void setupAudioPipeline() {
   delay1.delay(0, 200);
   filter1.frequency(500);
   filter1.resonance(0.7);
+
+  feedbackMixer.gain(0, 1.0f);
+  feedbackMixer.gain(1, feedbackAmount);
 
   // Basic limiter settings to keep level in check
   limiter1.attack(5);

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -72,7 +72,8 @@ void updateControl() {
   delay1.delay(0, map(potDelayValue, 0, 1023, 1, 300));
 
   int potFeedbackValue = analogRead(potFeedbackPin);
-  float feedback = map(potFeedbackValue, 0, 1023, 0, 100) / 100.0;
+  feedbackAmount = map(potFeedbackValue, 0, 1023, 0, 100) / 100.0;
+  feedbackMixer.gain(1, feedbackAmount);
 
   noiseAmount = map(analogRead(potNoiseAmountPin), 0, 1023, 0, 60);
   density = map(analogRead(potDensityPin), 0, 1023, 0, 100);
@@ -80,7 +81,7 @@ void updateControl() {
 
   // Output debug information over serial
   Serial.print("Delay: "); Serial.print(potDelayValue);
-  Serial.print(" | Feedback: "); Serial.print(feedback);
+  Serial.print(" | Feedback: "); Serial.print(feedbackAmount);
   Serial.print(" | Noise: "); Serial.print(noiseAmount);
   Serial.print(" | Density: "); Serial.print(density);
   Serial.print(" | Mix: "); Serial.println(mixAmount);


### PR DESCRIPTION
## Summary
- expose new `feedbackAmount` global for controlling delay feedback
- wire delay output back into its input via `AudioMixer4`
- update controls to adjust the mixer gain based on the feedback pot
- document the new parameter in the README

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640c3bb47483258768969620e6d8e6